### PR TITLE
Fix room user visibility after joining

### DIFF
--- a/SERVER/server.js
+++ b/SERVER/server.js
@@ -26,6 +26,7 @@ io.on('connection', (socket) => {
     console.log('User connected:', socket.id);
 
     socket.on('create-room', ({ playerName }) => {
+        console.log('Creating room for player:', playerName);
         const newRoomCode = Math.random().toString(36).substring(2, 8).toUpperCase();
         const room = {
             players: {
@@ -43,13 +44,16 @@ io.on('connection', (socket) => {
         rooms.set(newRoomCode, room);
         socket.join(newRoomCode);
 
+        console.log('Room created:', newRoomCode, 'Players:', room.players);
         socket.emit('room-created', { roomCode: newRoomCode, playerId: socket.id });
         io.to(newRoomCode).emit('players-update', room.players);
     });
 
     socket.on('join-room', ({ roomCode, playerName }) => {
+        console.log('Joining room:', roomCode, 'Player:', playerName);
         const room = rooms.get(roomCode);
         if (!room) {
+            console.log('Room not found:', roomCode);
             socket.emit('room-error', { message: 'Room not found' });
             return;
         }
@@ -63,6 +67,7 @@ io.on('connection', (socket) => {
         };
         socket.join(roomCode);
 
+        console.log('Player joined room:', roomCode, 'All players:', room.players);
         socket.emit('room-joined', { roomCode, playerId: socket.id });
         io.to(roomCode).emit('players-update', room.players);
 
@@ -114,7 +119,7 @@ io.on('connection', (socket) => {
     });
 });
 
-const PORT = process.env.PORT || 3001;
+const PORT = process.env.PORT || 5000;
 server.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Resolve multiplayer room player visibility by unifying client and server socket implementations.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `MultiplayerMenu` used a simulated socket, preventing actual room creation/joining on the server. This PR updates the menu to use a real socket.io connection and aligns event handling across client components and the server, ensuring players are correctly registered and displayed in rooms.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b2814db-7fbe-452f-b641-97168a954e40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b2814db-7fbe-452f-b641-97168a954e40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>